### PR TITLE
Fix AudioPlayer's destructor

### DIFF
--- a/just_audio_windows/windows/player.hpp
+++ b/just_audio_windows/windows/player.hpp
@@ -214,6 +214,7 @@ public:
     });
   }
   AudioPlayer::~AudioPlayer() {
+    player_channel_->SetMethodCallHandler(nullptr);
     mediaPlayer.Close();
   }
 


### PR DESCRIPTION
If you do not call player_channel_->SetMethodCallHandler() in the destructor, it is possible that when the AudioPlayer is frequently created and destroyed on the Dart side, the lambda function (line 141) of the destroyed AudioPlayer will be called. In the closure of the call, this object has been destroyed, so a Native exception will be triggered, causing the application to exit.